### PR TITLE
[#4] Github Actions가 develop 브랜치에서만 수행되도록 수정한다.

### DIFF
--- a/.github/workflows/github-actions-test.yml
+++ b/.github/workflows/github-actions-test.yml
@@ -1,6 +1,10 @@
 name: GitHub Actions Test
 run-name: ${{ github.actor }} is testing GitHub Actions
-on: [push]
+on:
+  push:
+    branches:
+      - develop
+      
 jobs:
   Test-GitHub-Actions:
     runs-on: ubuntu-latest


### PR DESCRIPTION
```yaml
on:
  push:
    branches:
      - develop
```

활동 유형 및 필터를 추가해서 develop에 push할 때만 워크플로우가 수행되도록 수정한다.

close #4