### PR TITLE
[#8] GitHub Actions 지속적인 통합(CI)을 위한 yml 파일 문법 오류를 수정한다.

### DIFF
--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -12,16 +12,13 @@ jobs:
     steps:
       - name: Current Repository Checkout
         uses: actions/checkout@v3
-
       - name: Java 17 설치
         uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: temurin
-
       - name: Gradle Wrapper Validation
         uses: gradle/wrapper-validation-action@v1
-
       - name: Gradle Build Action
         uses: gradle/gradle-build-action@v2.6.0
         with:

--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Current Repository Checkout
-      - uses: actions/checkout@v3
+        uses: actions/checkout@v3
 
       - name: Java 17 설치
         uses: actions/setup-java@v3


### PR DESCRIPTION
- name에는 최소한 하나 이상의 uses가 들어가야 한다.

close #8 